### PR TITLE
refactor: Update tab title logic in FolderGroup and BookmarksGroup

### DIFF
--- a/src/main/java/krasa/editorGroups/model/BookmarksGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/BookmarksGroup.kt
@@ -111,6 +111,26 @@ class BookmarksGroup(val bookmarkGroup: BookmarkGroup?, val project: Project) : 
 
   override fun toString(): String = "BookmarksGroup{links=$links, name='$name'}"
 
+  override fun getTabTitle(
+    project: Project,
+    presentableNameForUI: String,
+    showSize: Boolean
+  ): String {
+    var nameForUI = presentableNameForUI
+    val size = size(project)
+    val isEmptyName = name.isEmpty()
+
+    return when {
+      showSize     -> when {
+        !isEmptyName -> "[${name}:$size] $nameForUI"
+        else         -> "[$size] $nameForUI"
+      }
+
+      !isEmptyName -> "[$name] $nameForUI"
+      else         -> nameForUI
+    }
+  }
+
   override fun hashCode(): Int {
     var result = id.hashCode()
     result = 31 * result + links.hashCode()

--- a/src/main/java/krasa/editorGroups/model/EditorGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/EditorGroup.kt
@@ -71,6 +71,22 @@ abstract class EditorGroup {
     }
   }
 
+  open fun getTabTitle(project: Project, presentableNameForUI: String, showSize: Boolean): String {
+    var nameForUI = presentableNameForUI
+    val isEmptyTitle = StringUtil.isEmpty(title)
+    val size = size(project)
+
+    return when {
+      showSize      -> when {
+        !isEmptyTitle -> "[${title}:$size] $nameForUI"
+        else          -> "[$size] $nameForUI"
+      }
+
+      !isEmptyTitle -> "[$title] $nameForUI"
+      else          -> nameForUI
+    }
+  }
+
   /**
    * Checks if the given project contains a link with the specified current file path.
    *

--- a/src/main/java/krasa/editorGroups/model/EditorGroups.kt
+++ b/src/main/java/krasa/editorGroups/model/EditorGroups.kt
@@ -34,16 +34,12 @@ class EditorGroups : EditorGroup, GroupsHolder {
   /** no filtering by type */
   constructor(result: EditorGroup, editorGroups: List<EditorGroup>) {
     addGroup(result)
-    for (group in editorGroups) {
-      addGroup(group)
-    }
+    editorGroups.forEach { group -> addGroup(group) }
   }
 
   private fun addGroup(group: EditorGroup) {
     when (group) {
-      is GroupsHolder -> group.groups?.let { groups ->
-        groups.filterNotNull().associateByTo(groupsMap, EditorGroup::id)
-      }
+      is GroupsHolder -> group.groups.toList().associateByTo(groupsMap, EditorGroup::id)
 
       else            -> groupsMap[group.id] = group
     }

--- a/src/main/java/krasa/editorGroups/model/FolderGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/FolderGroup.kt
@@ -30,6 +30,20 @@ class FolderGroup(
 
   override fun getPresentableTitle(project: Project, presentableNameForUI: String, showSize: Boolean): String = "Current folder"
 
+  override fun getTabTitle(
+    project: Project,
+    presentableNameForUI: String,
+    showSize: Boolean
+  ): String {
+    var nameForUI = presentableNameForUI
+    val size = size(project)
+
+    return when {
+      showSize -> "[$size] $nameForUI"
+      else     -> nameForUI
+    }
+  }
+
   override fun toString(): String = "FolderGroup{links=${links.size}, stub='$isStub'}"
 
   class FolderGroupScope : NamedScope(

--- a/src/main/java/krasa/editorGroups/model/SameNameGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/SameNameGroup.kt
@@ -26,6 +26,20 @@ class SameNameGroup(
 
   override fun getPresentableTitle(project: Project, presentableNameForUI: String, showSize: Boolean): String = "By same file name"
 
+  override fun getTabTitle(
+    project: Project,
+    presentableNameForUI: String,
+    showSize: Boolean
+  ): String {
+    var nameForUI = presentableNameForUI
+    val size = size(project)
+
+    return when {
+      showSize -> "[$size] $nameForUI"
+      else     -> nameForUI
+    }
+  }
+
   override fun toString(): String =
     "SameNameGroup{fileNameWithoutExtension='$fileNameWithoutExtension', links=$links, valid=$isValid, stub='$isStub'}"
 

--- a/src/main/java/krasa/editorGroups/services/TabGroupColorizer.kt
+++ b/src/main/java/krasa/editorGroups/services/TabGroupColorizer.kt
@@ -25,11 +25,12 @@ class TabGroupColorizer {
 
   fun getColor(project: Project, tabInfo: @NlsContexts.TabTitle String): Color? {
     val lastGroup = EditorGroupManager.getInstance(project).lastGroup
-    if (lastGroup.isStub) return null
-
-    if (!lastGroup.containsLink(project, tabInfo)) return null
-
-    return lastGroup.bgColor
+    return when {
+      lastGroup.isStub                           -> null
+      !EditorGroupsSettings.instance.isColorTabs -> null
+      !lastGroup.containsLink(project, tabInfo)  -> null
+      else                                       -> lastGroup.bgColor
+    }
   }
 
   companion object {


### PR DESCRIPTION
Update the `getTabTitle` method in `FolderGroup` and `BookmarksGroup` classes
to correctly display tab titles based on `showSize` and `isEmptyName` conditions.