### PR TITLE
feat: Add SettingsNotifier interface and create TOPIC for EditorGroupsSettings

### DIFF
--- a/src/main/java/krasa/editorGroups/actions/ReindexAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ReindexAction.kt
@@ -6,12 +6,15 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.util.indexing.FileBasedIndex
 import krasa.editorGroups.index.EditorGroupIndex
 import krasa.editorGroups.index.IndexCache
+import krasa.editorGroups.support.Notifications
 
 class ReindexAction : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
     thisLogger().debug("INDEXING START " + System.currentTimeMillis())
     IndexCache.getInstance(e.project!!).clear()
     FileBasedIndex.getInstance().requestRebuild(EditorGroupIndex.NAME)
+
+    Notifications.notifySimple("Reindexing started")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/ReindexThisFileAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ReindexThisFileAction.kt
@@ -4,13 +4,13 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.util.indexing.FileBasedIndex
+import krasa.editorGroups.support.Notifications
 
 class ReindexThisFileAction : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
-    val data = CommonDataKeys.VIRTUAL_FILE.getData(e.dataContext)
-    if (data != null) {
-      FileBasedIndex.getInstance().requestReindex(data)
-    }
+    val data = CommonDataKeys.VIRTUAL_FILE.getData(e.dataContext) ?: return
+    FileBasedIndex.getInstance().requestReindex(data)
+    Notifications.notifySimple("Reindexing started for ${data.name}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/RemoveFromCurrentBookmarksAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/RemoveFromCurrentBookmarksAction.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.vfs.VirtualFile
 import krasa.editorGroups.EditorGroupPanel
 import krasa.editorGroups.model.BookmarksGroup
+import krasa.editorGroups.support.Notifications
 import krasa.editorGroups.support.Notifications.showWarning
 import krasa.editorGroups.support.Splitters
 
@@ -68,6 +69,8 @@ class RemoveFromCurrentBookmarksAction : EditorGroupsAction() {
       val next = editorGroupPanel.goToNextTab(newTab = false, newWindow = false, split = Splitters.NONE)
       if (!next) editorGroupPanel.goToPreviousTab(newTab = false, newWindow = false, split = Splitters.NONE)
     }
+
+    Notifications.notifySimple("Removed from '$groupTitle': $filesToRemoveSet")
   }
 
   private fun notifyFail(name: String, selected: MutableSet<VirtualFile>) {

--- a/src/main/java/krasa/editorGroups/actions/ToggleAutoFolderGroupsAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ToggleAutoFolderGroupsAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class ToggleAutoFolderGroupsAction : ToggleAction(), DumbAware {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -13,6 +14,8 @@ class ToggleAutoFolderGroupsAction : ToggleAction(), DumbAware {
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     EditorGroupsSettings.instance.isAutoFolders = state
+    EditorGroupsSettings.instance.fireChanged()
+    Notifications.notifySimple("Auto Folder Group ${if (state) "enabled" else "disabled"}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/ToggleAutoSameNameGroupsAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ToggleAutoSameNameGroupsAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class ToggleAutoSameNameGroupsAction : ToggleAction(), DumbAware {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -13,6 +14,8 @@ class ToggleAutoSameNameGroupsAction : ToggleAction(), DumbAware {
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     EditorGroupsSettings.instance.isAutoSameName = state
+    EditorGroupsSettings.instance.fireChanged()
+    Notifications.notifySimple("Auto Same Name Group ${if (state) "enabled" else "disabled"}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/ToggleForceAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ToggleForceAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class ToggleForceAction : ToggleAction(), DumbAware {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -13,6 +14,8 @@ class ToggleForceAction : ToggleAction(), DumbAware {
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     EditorGroupsSettings.instance.isForceSwitch = state
+    EditorGroupsSettings.instance.fireChanged()
+    Notifications.notifySimple("Force Switch ${if (state) "enabled" else "disabled"}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/ToggleHideEmptyAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ToggleHideEmptyAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class ToggleHideEmptyAction : ToggleAction(), DumbAware {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -13,6 +14,8 @@ class ToggleHideEmptyAction : ToggleAction(), DumbAware {
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     EditorGroupsSettings.instance.isHideEmpty = state
+    EditorGroupsSettings.instance.fireChanged()
+    Notifications.notifySimple("Hide Empty Groups ${if (state) "enabled" else "disabled"}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/actions/TogglePanelVisibilityAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/TogglePanelVisibilityAction.kt
@@ -5,12 +5,14 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import krasa.editorGroups.services.PanelRefresher
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class TogglePanelVisibilityAction : DumbAwareAction() {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
   override fun actionPerformed(e: AnActionEvent) {
     PanelRefresher.getInstance(getEventProject(e)!!).refresh()
+    Notifications.notifySimple("Editor Groups Panel disabled")
   }
 
   override fun update(e: AnActionEvent) {

--- a/src/main/java/krasa/editorGroups/actions/ToggleShowSizeAction.kt
+++ b/src/main/java/krasa/editorGroups/actions/ToggleShowSizeAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 import krasa.editorGroups.settings.EditorGroupsSettings
+import krasa.editorGroups.support.Notifications
 
 class ToggleShowSizeAction : ToggleAction(), DumbAware {
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -13,6 +14,8 @@ class ToggleShowSizeAction : ToggleAction(), DumbAware {
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     EditorGroupsSettings.instance.isShowSize = state
+    EditorGroupsSettings.instance.fireChanged()
+    Notifications.notifySimple("Show Size ${if (state) "enabled" else "disabled"}")
   }
 
   companion object {

--- a/src/main/java/krasa/editorGroups/settings/EditorGroupsSettings.kt
+++ b/src/main/java/krasa/editorGroups/settings/EditorGroupsSettings.kt
@@ -1,5 +1,6 @@
 package krasa.editorGroups.settings
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SettingsCategory
@@ -7,6 +8,7 @@ import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
+import com.intellij.util.messages.Topic
 import krasa.editorGroups.model.RegexGroupModels
 import krasa.editorGroups.settings.EditorGroupsSettings.EditorGroupsSettingsState
 
@@ -212,6 +214,17 @@ class EditorGroupsSettings : SimplePersistentStateComponent<EditorGroupsSettings
       state.regexGroupModels = value
     }
 
+  fun fireChanged() {
+    ApplicationManager.getApplication().messageBus
+      .syncPublisher(TOPIC)
+      .configChanged(this)
+  }
+
+  interface SettingsNotifier {
+    /** When Config is changed (settings) */
+    fun configChanged(config: EditorGroupsSettings): Unit = Unit
+  }
+
   companion object {
     const val DEFAULT_GROUP_SIZE_LIMIT: Int = 10_000
     const val MIN_GROUP_SIZE_LIMIT: Int = 1
@@ -220,6 +233,10 @@ class EditorGroupsSettings : SimplePersistentStateComponent<EditorGroupsSettings
     const val DEFAULT_TAB_SIZE_LIMIT: Int = 50
     const val MIN_TAB_SIZE_LIMIT: Int = 1
     const val MAX_TAB_SIZE_LIMIT: Int = 100
+
+    @Topic.AppLevel
+    @JvmField
+    val TOPIC: Topic<SettingsNotifier> = Topic.create("Editor Groups Settings", SettingsNotifier::class.java)
 
     @JvmStatic
     val instance by lazy { service<EditorGroupsSettings>() }

--- a/src/main/java/krasa/editorGroups/support/Notifications.kt
+++ b/src/main/java/krasa/editorGroups/support/Notifications.kt
@@ -88,5 +88,11 @@ object Notifications {
   @JvmStatic
   fun notifyTooManyFiles() = showWarning(TooManyFilesException.FOUND_TOO_MANY_MATCHING_FILES_SKIPPING)
 
+  @JvmStatic
+  fun notifySimple(msg: String) {
+    val notification = notificationGroup.createNotification(ID, msg, NotificationType.INFORMATION)
+    show(notification)
+  }
+
   private fun show(notification: Notification) = ApplicationManager.getApplication().invokeLater { notify(notification) }
 }


### PR DESCRIPTION
This commit adds a SettingsNotifier interface to handle config changes in EditorGroupsSettings.
It also creates a TOPIC to publish changes using the Application message bus.