### PR TITLE
✨ refactor: Update PopupMenu and tab title logic

### DIFF
--- a/src/main/java/krasa/editorGroups/actions/PopupMenu.kt
+++ b/src/main/java/krasa/editorGroups/actions/PopupMenu.kt
@@ -7,7 +7,7 @@ import krasa.editorGroups.EditorGroupPanel
 import java.awt.Component
 
 object PopupMenu {
-  val actions = listOf(
+  val actions: List<String> = listOf(
     SwitchGroupAction.ID,
     SwitchFileAction.ID,
     "-",
@@ -28,7 +28,7 @@ object PopupMenu {
     "-",
     ToggleCompactModeGroupsAction.ID,
     ToggleColorizeGroupsAction.ID,
-    // ToggleShowSizeAction.ID,
+    ToggleShowSizeAction.ID,
     "-",
     OpenConfigurationAction.ID
   )

--- a/src/main/java/krasa/editorGroups/extensions/EditorGroupTabTitleProvider.kt
+++ b/src/main/java/krasa/editorGroups/extensions/EditorGroupTabTitleProvider.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.ui.EDT
 import krasa.editorGroups.EditorGroupPanel
 import krasa.editorGroups.model.EditorGroup
-import krasa.editorGroups.settings.EditorGroupsSettings
 import java.io.File
 
 class EditorGroupTabTitleProvider : EditorTabTitleProvider {
@@ -42,7 +41,6 @@ class EditorGroupTabTitleProvider : EditorTabTitleProvider {
       currentTitle = group.getTabTitle(
         project = project,
         presentableNameForUI = currentTitle,
-        showSize = EditorGroupsSettings.instance.isShowSize
       )
     }
 

--- a/src/main/java/krasa/editorGroups/model/BookmarksGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/BookmarksGroup.kt
@@ -120,18 +120,11 @@ class BookmarksGroup(val bookmarkGroup: BookmarkGroup?, val project: Project) : 
   override fun getTabTitle(
     project: Project,
     presentableNameForUI: String,
-    showSize: Boolean
   ): String {
     var nameForUI = presentableNameForUI
-    val size = size(project)
     val isEmptyName = name.isEmpty()
 
     return when {
-      showSize     -> when {
-        !isEmptyName -> "[${name}:$size] $nameForUI"
-        else         -> "[$size] $nameForUI"
-      }
-
       !isEmptyName -> "[$name] $nameForUI"
       else         -> nameForUI
     }
@@ -159,8 +152,10 @@ class BookmarksGroup(val bookmarkGroup: BookmarkGroup?, val project: Project) : 
 
   companion object {
     const val ID_PREFIX: String = "BOOKMARKS"
+
+    @NonNls
     const val BOOKMARKS_GROUP_SCOPE_ID: String = "krasa.editorGroups.model.BookmarksGroup"
-    const val BOOKMARKS_GROUP_SCOPE_NAME: String = "Editor Groups: Bookmarks"
+    val BOOKMARKS_GROUP_SCOPE_NAME: String = message("group.bookmarks.scope")
     val BOOKMARKS_GROUP_SCOPE: NamedScope = BookmarksGroupScope()
   }
 }

--- a/src/main/java/krasa/editorGroups/model/EditorGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/EditorGroup.kt
@@ -61,11 +61,12 @@ abstract class EditorGroup {
     var nameForUI = presentableNameForUI
     val isEmptyTitle = StringUtil.isEmpty(title)
     val size = size(project)
+    val doShowSize = EditorGroupsSettings.instance.isShowSize && showSize
 
     return when {
-      showSize      -> when {
-        !isEmptyTitle -> "[${this.title}:$size] $nameForUI"
-        else          -> "[$size] $nameForUI"
+      doShowSize    -> when {
+        !isEmptyTitle -> "[${this.title}] $nameForUI ($size)"
+        else          -> "$nameForUI ($size)"
       }
 
       !isEmptyTitle -> "[$title] $nameForUI"
@@ -73,17 +74,12 @@ abstract class EditorGroup {
     }
   }
 
-  open fun getTabTitle(project: Project, presentableNameForUI: String, showSize: Boolean): String {
+  /** Returns the text to display on the tabs (for the EditorTabTitleProvider) */
+  open fun getTabTitle(project: Project, presentableNameForUI: String): String {
     var nameForUI = presentableNameForUI
     val isEmptyTitle = StringUtil.isEmpty(title)
-    val size = size(project)
 
     return when {
-      showSize      -> when {
-        !isEmptyTitle -> "[${title}:$size] $nameForUI"
-        else          -> "[$size] $nameForUI"
-      }
-
       !isEmptyTitle -> "[$title] $nameForUI"
       else          -> nameForUI
     }
@@ -151,10 +147,6 @@ abstract class EditorGroup {
       result = toPresentableName(ownerPath)
     }
 
-    if (EditorGroupsSettings.instance.isShowSize) {
-      result += ":${size(project)}"
-    }
-
     return result
   }
 
@@ -169,7 +161,7 @@ abstract class EditorGroup {
     val resultOwnerPath = ownerPath
     // Take the last element of the path without the ext
     val name = toPresentableName(resultOwnerPath)
-    return getPresentableTitle(project, name, false)
+    return getPresentableTitle(project = project, presentableNameForUI = name, showSize = true)
   }
 
   /**
@@ -178,7 +170,7 @@ abstract class EditorGroup {
    * @param project the project for which the tooltip is generated
    * @return the tooltip text for the tab group, or null if not found
    */
-  fun getTabGroupTooltipText(project: Project): String? = getPresentableTitle(project, message("owner.0", ownerPath), true)
+  fun getTabGroupTooltipText(project: Project): String? = getPresentableTitle(project = project, message("owner.0", ownerPath), true)
 
   /**
    * Checks if this EditorGroup is selected.

--- a/src/main/java/krasa/editorGroups/model/FolderGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/FolderGroup.kt
@@ -32,19 +32,7 @@ class FolderGroup(
 
   override fun getPresentableTitle(project: Project, presentableNameForUI: String, showSize: Boolean): String = message("current.folder")
 
-  override fun getTabTitle(
-    project: Project,
-    presentableNameForUI: String,
-    showSize: Boolean
-  ): String {
-    var nameForUI = presentableNameForUI
-    val size = size(project)
-
-    return when {
-      showSize -> "[$size] $nameForUI"
-      else     -> nameForUI
-    }
-  }
+  override fun getTabTitle(project: Project, presentableNameForUI: String): String = presentableNameForUI
 
   override fun toString(): String = "FolderGroup{links=${links.size}, stub='$isStub'}"
 
@@ -62,9 +50,8 @@ class FolderGroup(
   companion object {
     val DIRECTORY_INSTANCE: LightVirtualFile = LightVirtualFile("DIRECTORY_INSTANCE")
     val INSTANCE: FolderGroup = FolderGroup(DIRECTORY_INSTANCE, emptyList())
-
     const val FOLDER_GROUP_SCOPE_ID: String = "krasa.editorGroups.model.FolderGroup"
-    const val FOLDER_GROUP_SCOPE_NAME: String = "Editor Groups: Current Folder"
+    val FOLDER_GROUP_SCOPE_NAME: String = message("group.folder.scope")
     val FOLDER_GROUP_SCOPE: NamedScope = FolderGroupScope()
   }
 }

--- a/src/main/java/krasa/editorGroups/model/SameNameGroup.kt
+++ b/src/main/java/krasa/editorGroups/model/SameNameGroup.kt
@@ -31,16 +31,7 @@ class SameNameGroup(
   override fun getTabTitle(
     project: Project,
     presentableNameForUI: String,
-    showSize: Boolean
-  ): String {
-    var nameForUI = presentableNameForUI
-    val size = size(project)
-
-    return when {
-      showSize -> "[$size] $nameForUI"
-      else     -> nameForUI
-    }
-  }
+  ): String = presentableNameForUI
 
   override fun toString(): String =
     "SameNameGroup{fileNameWithoutExtension='$fileNameWithoutExtension', links=$links, valid=$isValid, stub='$isStub'}"
@@ -61,9 +52,8 @@ class SameNameGroup(
       fileNameWithoutExtension = "SAME_NAME_INSTANCE",
       links = emptyList(),
     )
-
     const val SAME_NAME_GROUP_SCOPE_ID: String = "krasa.editorGroups.model.SameNameGroup"
-    const val SAME_NAME_GROUP_SCOPE_NAME: String = "Editor Groups: Same Name"
+    val SAME_NAME_GROUP_SCOPE_NAME: String = message("group.same.name.scope")
     val SAME_NAME_GROUP_SCOPE: NamedScope = SameNameGroupScope()
   }
 }


### PR DESCRIPTION
Refactor the PopupMenu actions to include type specification for
better type safety. Simplify getTabTitle method in FolderGroup
and SameNameGroup classes to remove unused parameters. Enhance the
getPresentableTitle method in EditorGroup to conditionally show size
based on settings. This improves code clarity and maintains UI
consistency.